### PR TITLE
今できるTodoリストについての文言を修正

### DIFF
--- a/app/views/currentlocations/new.html.erb
+++ b/app/views/currentlocations/new.html.erb
@@ -7,7 +7,7 @@
 
 <div class="container-mid">
     <div class="content">
-        <p>今いる場所の近くで出来るTodoリストを作ります。</br></br> ※ボタンを押した後、しばらくお待ちください。</br>※ブラウザで現在地取得、ポップアップを許可してください。</p>
+        <p>現在地を取得すると、あなたが登録したTodoから今いる場所で出来るTodoをリストアップします。</br></br>※ボタンを押した後、しばらくお待ちください</br>※ブラウザで現在地取得、ポップアップを許可してください</br>※設定よりリストにピックアップされる距離範囲の設定ができます</p>
     </div>
     
     <button type="button" class="get-current-position-btn"><%= t ('.get') %></button>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,9 +1,9 @@
 ja:
   currentlocations:
     index:
-      title: '近くでできるTodo'
+      title: '今できるTodo'
     new:
-      title: '今できるTodoは？'
+      title: '今できるTodo'
       get: '現在地を取得する'
       check: '前回いた地点でのTodoを見る'
   todos:


### PR DESCRIPTION
## 概要

今できるTodoリストについての文言を修正

## 確認方法

・今できるTodoページで、文言が変更されたことを確認する。

旧）
今いる場所の近くで出来るTodoリストを作ります。
※ボタンを押した後、しばらくお待ちください。
※ブラウザで現在地取得、ポップアップを許可してください。

新）
現在地を取得すると、あなたが登録したTodoから今いる場所で出来るTodoをリストアップします。

※ボタンを押した後、しばらくお待ちください
※ブラウザで現在地取得、ポップアップを許可してください
※設定よりリストにピックアップされる距離範囲の設定ができます

## 影響範囲

## チェックリスト

- [x] 必要なドキュメントを作成した

## コメント

Close #58 