### PR TITLE
近くでできるTodoがない場合理由を表示する、Todo削除後のリダイレクト先を修正

### DIFF
--- a/app/assets/stylesheets/shared/none.scss
+++ b/app/assets/stylesheets/shared/none.scss
@@ -1,0 +1,5 @@
+.container-mid{
+    padding-top:100px;
+    text-align:center;
+    padding-bottom:100px;
+}

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -74,7 +74,7 @@ class TodosController < ApplicationController
 
 #もし紐づくtodoがなくなってしまった場合は、そのspotも削除する
   @todo.spot.destroy if @todo.spot.todos.nil?
-  redirect_to todos_url
+  redirect_back(fallback_location: todos_url)
  end
 
  def finish

--- a/app/views/currentlocations/index.html.erb
+++ b/app/views/currentlocations/index.html.erb
@@ -6,32 +6,39 @@
   <h1><%= t ('.title') %></h1>
 </div>
 
-<div class="pagenate">
-  <%= paginate @spots, theme: 'twitter-bootstrap-4' %>
-</div>
 
-<% @spots.each do |spot| %>
-  <div class="col-lg-4">
-    <div class="card mb-3">
-      <div class="card-body">
-        <h5 class="card-title"><%= spot.name %></h5>
-      </div>
+<% if @spots.empty? %>
+  <%= render 'shared/none' %>
+<% else %>
 
-      <ul class="list-group">
-        <% spot.todos.each do |todo| %>
-          <li class="list-group-item">
-            <div class="item-check">
-              <%= render 'checks/check', todo: todo  %>
-            </div>
-            <div class="item-content">
-              <%= todo.content %>
-            </div>
-            <div class="item-right">
-              <%= render 'todos/btn', todo: todo  %>
-            </div>
-          </li>
-        <% end %>
-      </ul>
-    </div>
+  <div class="pagenate">
+    <%= paginate @spots, theme: 'twitter-bootstrap-4' %>
   </div>
+
+  <% @spots.each do |spot| %>
+    <div class="col-lg-4">
+      <div class="card mb-3">
+        <div class="card-body">
+          <h5 class="card-title"><%= spot.name %></h5>
+        </div>
+
+        <ul class="list-group">
+          <% spot.todos.each do |todo| %>
+            <li class="list-group-item">
+              <div class="item-check">
+                <%= render 'checks/check', todo: todo  %>
+              </div>
+              <div class="item-content">
+                <%= todo.content %>
+              </div>
+              <div class="item-right">
+                <%= render 'todos/btn', todo: todo  %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
 <% end %>

--- a/app/views/shared/_none.html.erb
+++ b/app/views/shared/_none.html.erb
@@ -1,0 +1,5 @@
+<%= stylesheet_link_tag 'shared/none', media: 'all', 'data-turbolinks-track': 'reload' %>
+
+<div class='container-mid'>
+    <p>あなたが登録したTodoのうち、今いる場所の近くで出来るTodoはありませんでした。<br><br>自由な時間を楽しみましょう！</p>
+</div>


### PR DESCRIPTION
## 概要

・近くでできるTodoがない場合下記メッセージが表示される
「あなたが登録したTodoのうち、今いる場所の近くで出来るTodoはありませんでした。自由な時間を楽しみましょう！」
・Allや、今できるTodoでTodoを削除した場合、元々いたページにリダイレクトされる。

## 確認方法

メッセージ→目視確認
リダイレクト→操作確認

## 影響範囲

行った修正が影響するであろう範囲を記載しましょう。レビュアーが修正の影響範囲を予測する助けになります。

## チェックリスト

- [x] 必要なドキュメントを作成した

## コメント

Close #60 