### PR TITLE
Todoのチェックができない不具合解消

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -79,7 +79,7 @@ class TodosController < ApplicationController
 
  def finish
    @todo= Todo.find(params[:id])
-   @todo.update_attributes(finished:true)
+   @todo.update(finished:true)
 
    #現在のユーザーでお気に入りを作成
    respond_to do |format|
@@ -90,7 +90,7 @@ class TodosController < ApplicationController
 
  def continue
    @todo= Todo.find(params[:id])
-   @todo.update_attributes(finished:false)
+   @todo.update(finished:false)
 
    #現在のユーザーでお気に入りを作成
    respond_to do |format|


### PR DESCRIPTION
## 概要

Todoのチェックができない不具合解消
メソッドをupdate_attributes→updateに変更 ※rails6.1以降は使用できなくなったため

## 確認方法

todoのチェックができるようになったことを確認する

## 影響範囲


## チェックリスト

- [x] 必要なドキュメントを作成した

## コメント

Close #62 