### PR TITLE
cron　チェック済みタスクの削除自動実行

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,9 @@ gem 'bootstrap4-kaminari-views'
 #検索機能
 gem 'ransack'
 
+#Todo自動削除
+gem 'whenever', require: false
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   # gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,11 @@ gem 'bootstrap4-kaminari-views'
 #検索機能
 gem 'ransack'
 
-#Todo自動削除
+#rakeタスク（Todo自動削除）の定期実行（cron）をrailsで使用するため
 gem 'whenever', require: false
+
+#cron実行時の警告メッセージ「already initialized constant Net::ProtocRetryError」回避のため
+gem 'net-http'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,8 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.2)
     multi_xml (0.6.0)
+    net-http (0.3.2)
+      uri
     net-imap (0.3.7)
       date
       net-protocol
@@ -355,6 +357,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.4.2)
+    uri (0.12.2)
     version_gem (1.1.3)
     web-console (4.2.1)
       actionview (>= 6.0.0)
@@ -393,6 +396,7 @@ DEPENDENCIES
   line-bot-api
   listen
   loofah
+  net-http
   pg
   pry-rails
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    chronic (0.10.2)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -364,6 +365,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.11)
@@ -408,6 +411,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   web-console
+  whenever
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -46,6 +46,7 @@
 
 /* 編集・削除ボタン */
 
+
 i{
   margin-right:5px;
   color:#D4DEDD;
@@ -60,6 +61,14 @@ text-decoration: none;
   right : 0;
   position: absolute;
 
+}
+
+.edit_btn{
+  float:left;
+}
+
+.delete_btn{
+  float:right;
 }
 
 /* チェックボタンのふきだし */

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -61,3 +61,34 @@ text-decoration: none;
   position: absolute;
 
 }
+
+/* チェックボタンのふきだし */
+
+.balloonoya {
+  position: relative;                /* 指定した分だけ相対的に移動 */
+}
+.balloonoya:hover .balloon {
+  display: inline;                /* インライン要素として表示 */
+}
+.balloon {
+  position: absolute;                /* 親要素を基準 */
+  display: none;                        /* 要素を非表示 */
+  padding: 6px;                         /* テキストの前後の余白 */
+  background-color: #F2C67F;       /* 背景色（透明度） */
+  width: 150px;                          /* 吹き出し全体の幅 */
+  top: 100%;                           /* 表示位置 */
+  margin-top: 12px;                    /* 表示位置 */
+  font-size: 80%;                       /* 文字サイズ */
+  color: black;
+  text-align: center;
+  border-radius: 10px;
+}
+.balloon:after{
+  border-bottom: 12px solid #F2C67F; /* 吹き出し口の高さ・色 */
+  border-left: 5px solid transparent;    /* 吹き出し口の幅１／２ */
+  border-right: 10px solid transparent;   /* 吹き出し口の幅１／２ */
+  top: -12px;                             /* 吹き出し口の位置調整 */
+  left: 5px;                              /* 吹き出し口の横位置 */
+  content: "";                       /* コンテンツの挿入 */
+  position: absolute;                /* 親要素を基準 */
+}

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -11,9 +11,8 @@ class Spot < ApplicationRecord
     validates :latitude, presence: true
     validates :longitude, presence: true
 
-
-    def self.ransackable_attributes(auth_object = nil)
-        ["name"]
+    def self.ransackable_attributes(_auth_object = nil)
+        ['name']
     end
 
 end

--- a/app/views/checks/_continue.html.erb
+++ b/app/views/checks/_continue.html.erb
@@ -2,5 +2,8 @@
     id: "js-check-button-for-todo-#{todo.id}",
     method: :patch,
     remote: true do %>
-  <%= icon 'far', 'square fa-lg' %>
+
+  <div class='balloonoya'>
+    <%= icon 'far', 'square fa-lg' %><span class='balloon'>チェックしたTodoは<br>1週間後に削除されます</span>
+  </div>
 <% end %>

--- a/app/views/checks/_finished.html.erb
+++ b/app/views/checks/_finished.html.erb
@@ -2,5 +2,8 @@
     id: "js-check-button-for-todo-#{todo.id}",
     method: :patch,
     remote: true do %>
-    <%= icon 'fa', 'check-square fa-lg' %>
+    
+    <div class='balloonoya'>
+        <%= icon 'fa', 'check-square fa-lg' %><span class='balloon'>チェックしたTodoは<br>1週間後に削除されます</span>
+    </div>
 <% end %>

--- a/app/views/checks/continue.js.erb
+++ b/app/views/checks/continue.js.erb
@@ -1,1 +1,2 @@
 $('#js-check-button-for-todo-<%= @todo.id %>').replaceWith("<%= j(render partial: 'checks/continue', locals: { todo: @todo }) %>");
+$('#edit-btn-<%= @todo.id %>').css('display', 'block');

--- a/app/views/checks/finished.js.erb
+++ b/app/views/checks/finished.js.erb
@@ -1,1 +1,2 @@
 $('#js-check-button-for-todo-<%= @todo.id %>').replaceWith("<%= j(render partial: 'checks/finished', locals: { todo: @todo }) %>");
+$('#edit-btn-<%= @todo.id %>').css('display', 'none');

--- a/app/views/todos/_btn.html.erb
+++ b/app/views/todos/_btn.html.erb
@@ -1,7 +1,9 @@
-<div class='btn-group'>
-    <%= link_to edit_todo_path(todo.id) do %>
+<div class="edit_btn">
+    <%= link_to edit_todo_path(todo.id), id: "edit-btn-#{todo.id}" do %>
         <%= icon 'fa', 'pen fa-lg' %>
     <% end %>
+</div>
+<div class="delete_btn">  
     <%= link_to todo_path(todo.id), method: :delete, data: { confirm: 'todoを削除してもよろしいですか？' } do %>
         <%= icon 'fas', 'trash fa-lg' %>
     <% end %>

--- a/app/views/todos/_btn.html.erb
+++ b/app/views/todos/_btn.html.erb
@@ -1,6 +1,12 @@
 <div class="edit_btn">
-    <%= link_to edit_todo_path(todo.id), id: "edit-btn-#{todo.id}" do %>
-        <%= icon 'fa', 'pen fa-lg' %>
+    <% if todo.finished == TRUE %>
+        <%= link_to edit_todo_path(todo.id), id: "edit-btn-#{todo.id}", style:'display:none' do %>
+            <%= icon 'fa', 'pen fa-lg' %>
+        <% end %>
+    <% else %>
+        <%= link_to edit_todo_path(todo.id), id: "edit-btn-#{todo.id}" do %>
+            <%= icon 'fa', 'pen fa-lg' %>
+        <% end %>
     <% end %>
 </div>
 <div class="delete_btn">  

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,11 @@ module SpoTodo
     # the framework and any gems in your application.
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    # Rails自体のアプリケーションの時刻の設定
+    config.time_zone = 'Tokyo'
+
+    # DBを読み書きする際に、DBに記録されている時間をどのタイムゾーンで読み込むかの設定
+    config.active_record.default_timezone = :local
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,5 @@
-
 # Rails.rootを使用するために必要
-require File.expand_path(File.dirname(__FILE__) + '/environment')
+require File.expand_path("#{File.dirname(__FILE__)}/environment")
 
 # cronを実行する環境変数
 rails_env = ENV['RAILS_ENV'] || :development
@@ -18,11 +17,9 @@ set :job_template, "/bin/zsh -l -c ':job'"
 # q!eval "$(rbenv init -)" ＝ rbenvを使用する初期設定
 # eval = 引数で渡した文字列をRubyのプログラムとして実行するメソッド %q!=文字列作成宣言
 env :PATH, ENV['PATH']
-job_type :rbenv_rake, %q!eval "$(rbenv init -)"; cd :path && :environment_variable=:environment bundle exec rake :task --silent :output!
+job_type :rbenv_rake, 'eval "$(rbenv init -)"; cd :path && :environment_variable=:environment bundle exec rake :task --silent :output'
 
-#定期実行したい処理を記入
-every 1.day, :at => '0:00' do
-    rbenv_rake 'delete:delete'
+# 定期実行したい処理を記入
+every 1.day, at: '0:00' do
+  rbenv_rake 'delete:delete'
 end
-  
-

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,17 @@
+
+# Rails.rootを使用するために必要
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+
+# cronを実行する環境変数
+rails_env = ENV['RAILS_ENV'] || :development
+
+# cronを実行する環境変数をセット
+set :environment, rails_env
+
+# cronのログの吐き出し場所
+set :output, "#{Rails.root}/log/cron.log"
+
+#定期実行したい処理を記入
+every 1.minute do
+  rake 'delete:delete'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,7 +11,18 @@ set :environment, rails_env
 # cronのログの吐き出し場所
 set :output, "#{Rails.root}/log/cron.log"
 
+# シェル、コマンド設定
+set :job_template, "/bin/zsh -l -c ':job'"
+
+# job_type「rbenv_rake」を作成
+# q!eval "$(rbenv init -)" ＝ rbenvを使用する初期設定
+# eval = 引数で渡した文字列をRubyのプログラムとして実行するメソッド %q!=文字列作成宣言
+env :PATH, ENV['PATH']
+job_type :rbenv_rake, %q!eval "$(rbenv init -)"; cd :path && :environment_variable=:environment bundle exec rake :task --silent :output!
+
 #定期実行したい処理を記入
-every 1.minute do
-  rake 'delete:delete'
+every 1.day, :at => '0:00' do
+    rbenv_rake 'delete:delete'
 end
+  
+

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,8 +1,6 @@
 namespace :delete do
-    desc "Todoをチェックしてから1週間以上経過していた場合は削除する" #description（説明）
-    task delete: :environment do #task_nameは自由につけられる
-        Todo.where("(finished = ?) AND (updated_at < ?)", true,Time.current.ago(7.days)).each do |checked_todo|
-            checked_todo.delete
-        end
-    end
+  desc 'Todoをチェックしてから1週間以上経過していた場合は削除する' # description（説明）
+  task delete: :environment do # task_nameは自由につけられる
+    Todo.where('(finished = ?) AND (updated_at < ?)', true, Time.current.ago(7.days)).each(&:delete)
+  end
 end

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,0 +1,8 @@
+namespace :delete do
+    desc "Todoをチェックしてから1週間以上経過していた場合は削除する" #description（説明）
+    task delete: :environment do #task_nameは自由につけられる
+        Todo.where("(finished = ?) AND (updated_at < ?)", true,Time.current.ago(1.days)).each do |checked_todo|
+            checked_todo.delete
+        end
+    end
+end

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,7 +1,7 @@
 namespace :delete do
     desc "Todoをチェックしてから1週間以上経過していた場合は削除する" #description（説明）
     task delete: :environment do #task_nameは自由につけられる
-        Todo.where("(finished = ?) AND (updated_at < ?)", true,Time.current.ago(1.days)).each do |checked_todo|
+        Todo.where("(finished = ?) AND (updated_at < ?)", true,Time.current.ago(7.days)).each do |checked_todo|
             checked_todo.delete
         end
     end


### PR DESCRIPTION
## 概要

・チェック済みtodoは１週間経過後、cronで定期実行で削除するように設定
・チェック済みのtodoには編集ボタンが表示されないように設定
・DBのタイムゾーンを日本時間に設定

## 確認方法

・目視確認
・該当するtodoがDBから消えていることを確認

## 影響範囲

・todo一覧ページの表示
・今いる場所でできるtodo一覧の表示
・ユーザーのtodoが問題なく管理できているか

## チェックリスト

- [ ] Lint のチェックをパスした
- [ ] 必要なドキュメントを作成した

## コメント
