### PR TITLE
metaタグ設置、モバイル版サイドバーにメニュー追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'whenever', require: false
 gem 'net-http'
 
 #metaタグ設定
-gem "meta-tags"
+gem 'meta-tags'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,9 @@ gem 'whenever', require: false
 #cron実行時の警告メッセージ「already initialized constant Net::ProtocRetryError」回避のため
 gem 'net-http'
 
+#metaタグ設定
+gem "meta-tags"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   # gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,8 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    meta-tags (2.18.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -396,6 +398,7 @@ DEPENDENCIES
   line-bot-api
   listen
   loofah
+  meta-tags
   net-http
   pg
   pry-rails

--- a/app/views/currentlocations/index.html.erb
+++ b/app/views/currentlocations/index.html.erb
@@ -1,3 +1,6 @@
+<% description 'あなたが登録したTodoのうち、今いる場所で出来るTodo一覧です' %>
+<% keywords '現在地, 現在地取得, 今できるTodo' %>
+
 <%= stylesheet_link_tag 'title', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'index', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'currentlocation/index', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/currentlocations/index.html.erb
+++ b/app/views/currentlocations/index.html.erb
@@ -3,7 +3,7 @@
 <%= stylesheet_link_tag 'currentlocation/index', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 <div class="title">
-  <h1><%= t ('.title') %></h1>
+  <h1><%= title t ('.title') %></h1>
   <div class="pagenate">
     <%= paginate @spots, theme: 'twitter-bootstrap-4' %>
   </div>

--- a/app/views/currentlocations/new.html.erb
+++ b/app/views/currentlocations/new.html.erb
@@ -2,7 +2,7 @@
 <%= stylesheet_link_tag 'currentlocation/new', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 <div class="title">
-    <h1><%= t ('.title') %></h1>
+    <h1><%= title t ('.title') %></h1>
 </div>
 
 <div class="container-mid">

--- a/app/views/currentlocations/new.html.erb
+++ b/app/views/currentlocations/new.html.erb
@@ -1,3 +1,6 @@
+<% description '現在地を取得すると、あなたが登録したTodoから今いる場所で出来るTodoをリストアップします' %>
+<% keywords '現在地, 現在地取得, 今できるTodo' %>
+
 <%= stylesheet_link_tag 'title', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'currentlocation/new', media: 'all', 'data-turbolinks-track': 'reload' %>
 

--- a/app/views/explanations/top.html.erb
+++ b/app/views/explanations/top.html.erb
@@ -1,3 +1,5 @@
+<% title t 'explanations.top.title' %>
+
 <%= stylesheet_link_tag 'explanation/top', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 <div class="container-mid">

--- a/app/views/explanations/top.html.erb
+++ b/app/views/explanations/top.html.erb
@@ -1,3 +1,6 @@
+<% description 'spoTodoとは サービスの使用方法' %>
+<% keywords 'spoTodoとは, 使用方法, spoTodo' %>
+
 <% title t 'explanations.top.title' %>
 
 <%= stylesheet_link_tag 'explanation/top', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>SpoTodo</title>
+    <%= display_meta_tags site: "spoTodo" %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-
   </head>
 
   <body>

--- a/app/views/oauths/login.html.erb
+++ b/app/views/oauths/login.html.erb
@@ -1,3 +1,5 @@
+<% title t 'oauths.login.title' %>
+
 <%= stylesheet_link_tag 'oauth/login', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 <div class="container-mid">

--- a/app/views/oauths/login.html.erb
+++ b/app/views/oauths/login.html.erb
@@ -1,3 +1,6 @@
+<% description 'spoTodoのログインページ' %>
+<% keywords 'ログイン, spoTodo' %>
+
 <% title t 'oauths.login.title' %>
 
 <%= stylesheet_link_tag 'oauth/login', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/shared/_mobile_sidebar.html.erb
+++ b/app/views/shared/_mobile_sidebar.html.erb
@@ -20,6 +20,7 @@
 <% else %>
     <nav class="nav">
         <ul class="nav_menu_ul">
+            <li class="nav_menu_li"><a href="/"><%= t 'shared.sidebar.top' %></span></a></li>
             <li class="nav_menu_li"><a href="/login"><%= t 'shared.sidebar.login' %></span></a></li>
             <li class="nav_menu_li"><a href="#"><%= t 'shared.sidebar.privacy_policy' %></a></li>
             <li class="nav_menu_li"><a href="#"><%= t 'shared.sidebar.terms_of_service' %></a></li>

--- a/app/views/todos/edit.html.erb
+++ b/app/views/todos/edit.html.erb
@@ -1,3 +1,6 @@
+<% description 'Todoの編集ページ' %>
+<% keywords 'Todo編集, 編集, Todo, spoTodo' %>
+
 <%= stylesheet_link_tag 'title', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'todo/form', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'todo/edit', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/todos/edit.html.erb
+++ b/app/views/todos/edit.html.erb
@@ -3,7 +3,7 @@
 <%= stylesheet_link_tag 'todo/edit', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 <div class="title">
-    <h1><%= t 'todos.edit.title' %></h1>
+    <h1><%= title t 'todos.edit.title' %></h1>
 </div>
 
 <div class="container-mid">

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -3,7 +3,7 @@
 <%= stylesheet_link_tag 'todo/index', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 <div class="title">
-  <h1><%= t 'todos.index.title' %></h1>
+  <h1><%= title t 'todos.index.title' %></h1>
   <div class='search_form'>
     <%= search_form_for @q, url: todos_path do |f| %>
       <%= f.search_field :name_cont, placeholder:"場所", class:'form' %>

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -1,3 +1,6 @@
+<% description 'Todoの一覧ページ' %>
+<% keywords 'Todo一覧, 一覧, Todo, spoTodo' %>
+
 <%= stylesheet_link_tag 'title', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'index', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'todo/index', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/todos/new.html.erb
+++ b/app/views/todos/new.html.erb
@@ -1,5 +1,5 @@
 <% description 'AddTodo Todoの追加ページ' %>
-<% keywords 'Todo追加, 通過, AddTodo, Todo, spoTodo' %>
+<% keywords 'Todo追加, 追加, AddTodo, Todo, spoTodo' %>
 
 <%= stylesheet_link_tag 'title', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'todo/form', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/todos/new.html.erb
+++ b/app/views/todos/new.html.erb
@@ -1,3 +1,6 @@
+<% description 'AddTodo Todoの追加ページ' %>
+<% keywords 'Todo追加, 通過, AddTodo, Todo, spoTodo' %>
+
 <%= stylesheet_link_tag 'title', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'todo/form', media: 'all', 'data-turbolinks-track': 'reload' %>
 

--- a/app/views/todos/new.html.erb
+++ b/app/views/todos/new.html.erb
@@ -2,7 +2,7 @@
 <%= stylesheet_link_tag 'todo/form', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 <div class="title">
-    <h1><%= t 'todos.new.title' %></h1>
+    <h1><%= title t 'todos.new.title' %></h1>
 </div>
 
 <div class="container-mid">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,6 @@
+<% description 'ユーザー設定ページ 今できるTodoでリスト抽出対処とする、現在地からの距離の設定ができます' %>
+<% keywords 'ユーザー設定, 設定, 距離設定, spoTodo' %>
+
 <%= stylesheet_link_tag 'title', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_link_tag 'user/edit', media: 'all', 'data-turbolinks-track': 'reload' %>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,7 +2,7 @@
 <%= stylesheet_link_tag 'user/edit', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 <div class="title">
-    <h1><%= t '.title' %></h1>
+    <h1><%= title t '.title' %></h1>
 </div>
 
 <div class="container-mid">   

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,9 +20,13 @@ ja:
       what: '何をしたい？'
       where: 'どこで？'
       search: '検索'
-      update: '更新'      
+      update: '更新' 
+  oauths:
+    login:
+      title: 'ログイン'    
   explanations:
     top:
+      title: 'spoTodoとは'
       start: 'スタート'
   users:
     edit:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -36,6 +36,7 @@ ja:
       logout: 'ログアウト'
   shared:
     sidebar:
+      top: 'spoTodoとは'
       login: 'ログイン'
       privacy_policy: 'プライバシーポリシー'
       terms_of_service: '利用規約'


### PR DESCRIPTION
## 概要

metaタグ設置、モバイル版サイドバーにメニュー追加

## 確認方法

・ページタイトルが適切なものになっていること
・検証ツールなどでhtmlを確認した際に、head内に適切な設定がされていること
・画面サイズが小さくなった際に出現するハンバーガーメニューにて
　spoTodoとはというリンクが追加されていること

## 影響範囲

アプリ全体、各ページ

## チェックリスト

- [ ] Lint のチェックをパスした
- [ ] 必要なドキュメントを作成した

## コメント

Close #70 